### PR TITLE
fixup image provision failure

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,7 @@ Vagrant.configure(2) do |config|
       set -e
       export DEBIAN_FRONTEND=noninteractive
       apt-get update
+      apt-get install -y libssl1.0.0 libssl-dev
       apt-get install -y git python-pip libpython2.7-dev libyaml-dev libffi-dev
       pip install ecdsa 'paramiko<2' markupsafe ansible
 


### PR DESCRIPTION
OpenSSLではなくlibsslを利用しないとprovision imageで失敗するようになっていたので修正しました。

```bash
==> image: Traceback (most recent call last):
==> image:   File "/usr/bin/pip", line 9, in <module>
==> image:
==> image: load_entry_point('pip==1.5.6', 'console_scripts', 'pip')()
==> image:   File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 356, in load_entry_point
==> image:
==> image: return get_distribution(dist).load_entry_point(group, name)
==> image:   File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2476, in load_entry_point
==> image:
==> image: return ep.load()
==> image:   File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2190, in load
==> image:
==> image: ['__name__'])
==> image:   File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 74, in <module>
==> image:
==> image: from pip.vcs import git, mercurial, subversion, bazaar  # noqa
==> image:   File "/usr/lib/python2.7/dist-packages/pip/vcs/mercurial.py", line 9, in <module>
==> image:
==> image: from pip.download import path_to_url
==> image:   File "/usr/lib/python2.7/dist-packages/pip/download.py", line 22, in <module>
==> image:
==> image: import requests, six
==> image:   File "/usr/lib/python2.7/dist-packages/requests/__init__.py", line 68, in <module>
==> image:
==> image: _attach_namespace(urllib3, 'requests.packages')
==> image:   File "/usr/lib/python2.7/dist-packages/requests/__init__.py", line 63, in _attach_namespace
==> image:     module = __import__(name)
==> image:   File "/usr/lib/python2.7/dist-packages/urllib3/contrib/pyopenssl.py", line 55, in <module>
==> image:     import OpenSSL.SSL
==> image:   File "/usr/lib/python2.7/dist-packages/OpenSSL/__init__.py", line 8, in <module>
==> image:     from OpenSSL import rand, crypto, SSL
==> image:   File "/usr/lib/python2.7/dist-packages/OpenSSL/rand.py", line 11, in <module>
==> image:     from OpenSSL._util import (
==> image:   File "/usr/lib/python2.7/dist-packages/OpenSSL/_util.py", line 4, in <module>
==> image:     binding = Binding()
==> image:   File "/usr/lib/python2.7/dist-packages/cryptography/hazmat/bindings/openssl/binding.py", line 89, in __init__
==> image:     self._ensure_ffi_initialized()
==> image:   File "/usr/lib/python2.7/dist-packages/cryptography/hazmat/bindings/openssl/binding.py", line 113, in _ensure_ffi_initialized
==> image:     libraries=libraries,
==> image:   File "/usr/lib/python2.7/dist-packages/cryptography/hazmat/bindings/utils.py", line 80, in build_ffi
==> image:     extra_link_args=extra_link_args,
==> image:   File "/usr/lib/python2.7/dist-packages/cffi/api.py", line 340, in verify
==> image:     lib = self.verifier.load_library()
==> image:   File "/usr/lib/python2.7/dist-packages/cffi/verifier.py", line 75, in load_library
==> image:     return self._load_library()
==> image:   File "/usr/lib/python2.7/dist-packages/cffi/verifier.py", line 151, in _load_library
==> image:     return self._vengine.load_library()
==> image:   File "/usr/lib/python2.7/dist-packages/cffi/vengine_cpy.py", line 149, in load_library
==> image:     raise ffiplatform.VerificationError(error)
==> image: cffi.ffiplatform.VerificationError: importing '/usr/lib/python2.7/dist-packages/cryptography/_Cryptography_cffi_813c10e0x7adb75f8.x86_64-linux-gnu.so': /usr/lib/python2.7/dist-packages/cryptography/_Cryptography_cffi_813c10e0x7adb75f8.x86_64-linux-gnu.so: symbol SSLv2_client_method, version OPENSSL_1.0.0 not defined in file libssl.so.1.0.0 with link time reference
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```